### PR TITLE
Fix ArchUnit MalformedURLException on Windows

### DIFF
--- a/subprojects/provider/provider.gradle.kts
+++ b/subprojects/provider/provider.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
 
     testCompile(project(":test-fixtures"))
     testCompile("com.squareup.okhttp3:mockwebserver:3.9.1")
-    testCompile("com.tngtech.archunit:archunit:0.8.0")
+    testCompile("com.tngtech.archunit:archunit:0.8.3")
 }
 
 


### PR DESCRIPTION
Signed-off-by: Dave Smith <dave.k.smith@gmail.com>

### Context
Improve kotlin-dsl Windows build by incorporating an upstream fix from ArchUnit [pull request 76](https://github.com/TNG/ArchUnit/pull/76), which was merged into ArchUnit's master branch on 2018-06-02.

See [build1.txt] (contains the error using ArchUnit 0.8.0) and [build2.txt] (does not contain the error using ArchUnit 0.8.3).  Both buildX.txt files were generated using the following sequence from Git Bash on Windows 10:

    ./gradlew clean customInstallation
    ./gradlew assemble
    ./gradlew check --info --stacktrace --console=plain --max-workers=1 --no-daemon >& buildX.txt

`dos2unix` was the only postprocessor used on each buildX.txt file to get rid of `^M` characters at the end of each line.

- [build1.txt]:  85,201 total lines;  1,162 through 83,339 containing repeats of the ArchUnit exception
- [build2.txt]:   3,035 total lines, very similar to [build1.txt]  in diff without the ArchUnit exceptions

[build1.txt]: https://github.com/gradle/kotlin-dsl/files/2217823/build1.txt
[build2.txt]: https://github.com/gradle/kotlin-dsl/files/2217822/build2.txt

### Contributor Checklist
- [x] Base the PR against the `develop` branch
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] (manual verification b/c Windows not supported in Travis CI) Provide integration tests to verify changes from a user perspective
- [ ] (manual verification b/c Windows not supported in Travis CI) Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
