### PR TITLE
maven-publish: update deprecated call

### DIFF
--- a/samples/maven-publish/build.gradle.kts
+++ b/samples/maven-publish/build.gradle.kts
@@ -13,11 +13,11 @@ repositories {
 }
 
 dependencies {
-    compile(kotlin("stdlib"))
+    implementation(kotlin("stdlib"))
 }
 
 val sourcesJar by tasks.registering(Jar::class) {
-    classifier = "sources"
+    archiveClassifier.set("sources")
     from(sourceSets.main.get().allSource)
 }
 


### PR DESCRIPTION
### Context
- Update deprecated `setClassifier` with `archiveClassifier`
- Update deprecated `compile` with `implementation`

### Contributor Checklist
- [x] Make sure that all commits are [signed off](https://git-scm.com/docs/git-commit#git-commit---signoff) to indicate that you agree to the terms of [Developer Certificate of Origin](https://developercertificate.org/).
- [ ] Provide integration tests to verify changes from a user perspective
- [ ] Provide unit tests to verify logic
- [x] Ensure that tests pass locally: `./gradlew check --parallel`
